### PR TITLE
Fix rebuild target value

### DIFF
--- a/src/compose/mod.rs
+++ b/src/compose/mod.rs
@@ -60,6 +60,7 @@ impl Compose for &'static str {
         if self != target {
             world.get_mut::<Text>(*state).unwrap().sections[0] =
                 TextSection::new(self.to_owned(), TextStyle::default());
+            *target = self;
         }
     }
 }
@@ -86,6 +87,7 @@ impl Compose for String {
         if self != target {
             world.get_mut::<Text>(*state).unwrap().sections[0] =
                 TextSection::new(self.clone(), TextStyle::default());
+            *target = self.clone();
         }
     }
 }


### PR DESCRIPTION
Hi!
Cool project!

Without updating target, the ui will rebuild every frame where self is no longer the starting value, and it will never show the starting value again after having changed away from it.

Reproduce by running the app example, it doesnt return to 0, but skips between -1 and +1.
